### PR TITLE
Extend sorted_robust API

### DIFF
--- a/pyomo/core/base/block.py
+++ b/pyomo/core/base/block.py
@@ -1359,7 +1359,7 @@ Components must now specify their rules explicitly using 'rule=' keywords.""" %
                 _items = ((None, comp),)
 
             if _sort_indices:
-                _items = sorted_robust(_items)
+                _items = sorted_robust(_items, key=itemgetter(0))
             if active is None or not isinstance(comp, ActiveIndexedComponent):
                 for idx, compData in _items:
                     yield (name, idx), compData

--- a/pyomo/core/base/misc.py
+++ b/pyomo/core/base/misc.py
@@ -14,6 +14,8 @@ import logging
 import sys
 import types
 
+from pyomo.core.expr import native_numeric_types
+
 logger = logging.getLogger('pyomo.core')
 
 
@@ -111,7 +113,9 @@ class _robust_sort_keyfcn(object):
 
     """
     def __init__(self, key=None):
-        self._typemap = {tuple: (3, tuple.__name__)}
+        # sort all native numeric types as if they were floats
+        self._typemap = {t: (1, float.__name__) for t in native_numeric_types}
+        self._typemap[tuple] =(3, tuple.__name__)
         self._key = key
 
     def __call__(self, val):

--- a/pyomo/core/base/misc.py
+++ b/pyomo/core/base/misc.py
@@ -110,8 +110,9 @@ class _robust_sort_keyfcn(object):
     _typemap without resorting to global variables.
 
     """
-    def __init__(self):
+    def __init__(self, key=None):
         self._typemap = {tuple: (3, tuple.__name__)}
+        self._key = key
 
     def __call__(self, val):
         """Generate a tuple ( str(type_name), val ) for sorting the value.
@@ -122,6 +123,9 @@ class _robust_sort_keyfcn(object):
         argument of the sort key.
 
         """
+        if self._key is not None:
+            val = self._key(val)
+
         try:
             i, _typename = self._typemap[val.__class__]
         except KeyError:
@@ -155,7 +159,7 @@ class _robust_sort_keyfcn(object):
             return _typename, id(val)
 
 
-def sorted_robust(arg):
+def sorted_robust(arg, key=None, reverse=False):
     """Utility to sort an arbitrary iterable.
 
     This returns the sorted(arg) in a consistent order by first tring
@@ -166,16 +170,16 @@ def sorted_robust(arg):
     """
     # It is possible that arg is a generator.  We need to cache the
     # elements returned by the generator in case 'sorted' raises an
-    # exception (this ensures we don't loose any elements).  Howevver,
+    # exception (this ensures we don't lose any elements).  However,
     # if we were passed a list, we do not want to make an unnecessary
     # copy.  Tuples are OK because tuple(a) will not copy a if it is
     # already a tuple.
     if type(arg) is not list:
         arg = tuple(arg)
     try:
-        return sorted(arg)
+        return sorted(arg, key=key, reverse=reverse)
     except:
-        return sorted(arg, key=_robust_sort_keyfcn())
+        return sorted(arg, key=_robust_sort_keyfcn(key), reverse=reverse)
 
 
 def _to_ustr(obj):

--- a/pyomo/core/tests/unit/test_base_misc.py
+++ b/pyomo/core/tests/unit/test_base_misc.py
@@ -38,6 +38,10 @@ class TestSortedRobust(unittest.TestCase):
         a = sorted_robust([3, 2, 1])
         self.assertEqual(a, [1, 2, 3])
 
+        # Testthat ints and floats are sorted as "numbers"
+        a = sorted_robust([3, 2.1, 1])
+        self.assertEqual(a, [1, 2.1, 3])
+
         a = sorted_robust([3, '2', 1])
         self.assertEqual(a, [1, 3, '2'])
 

--- a/pyomo/core/tests/unit/test_block.py
+++ b/pyomo/core/tests/unit/test_block.py
@@ -342,6 +342,15 @@ class TestGenerators(unittest.TestCase):
         self.assertEqual(sorted([id(comp) for comp in model.block_data_objects(sort=False)]),
                          sorted([id(comp) for comp in [model,]+model.component_data_lists[Block]]))
 
+    def test_mixed_index_type(self):
+        m = ConcreteModel()
+        m.I = Set(initialize=[1,'1',3.5,4])
+        m.x = Var(m.I)
+        v = list(m.component_data_objects(Var, sort=True))
+        self.assertEqual(len(v), 4)
+        for a,b in zip([m.x[1], m.x[3.5], m.x[4], m.x['1']], v):
+            self.assertIs(a, b)
+
 
 class HierarchicalModel(object):
     def __init__(self):


### PR DESCRIPTION
## Summary/Motivation:
The idea of your PR is generlly good, however, the sort in `_component_data_iter` really needs to use the `itemgetter(0)` so that sorting doesn't accidentally compare component data objects (the second item in the tuple).

This PR updates the `sorted_robust()` API so that it supports the `key=` and `reverse=` arguments and puts the `itemgetter)0) back in.  ...plus this adds a test of the problematic behavior from #1845

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
